### PR TITLE
Implement Issue #1

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -33,4 +33,4 @@ unset OBUSERNAME
 unset OBPASSWORD
 unset OBGUID
 unset OB_REST_PORT
-
+unset OBALLOWEDIP

--- a/ob_restart.sh
+++ b/ob_restart.sh
@@ -15,6 +15,5 @@ rm -f /tmp/openbazaard.pid
 #echo "PICKLE DANCE"
 #rm -f ~/.openbazaar/cache.pickle
 echo "STARTING SERVER"
-python openbazaard.py start -d  
+if [ -z $OBALLOWEDIP ]; then python openbazaard.py start -d; else python openbazaard.py start -da $OBALLOWEDIP; fi
 echo "############################################################"
-

--- a/settings.conf.default
+++ b/settings.conf.default
@@ -1,5 +1,6 @@
 export OBHOME="/home/myobuser/OpenBazaar-Server"  # The full path to your OpenBazaar-Server installation
-export OBUSERNAME='myobusername'            # Username to log into the Rest API     
+export OBUSERNAME='myobusername'            # Username to log into the Rest API
 export OBPASSWORD='myobpassword'            # Password to log into the Rest API
 export OBGUID='myobguid'                    # Not your @handle
 export OB_REST_PORT=18469                   # The REST port in case you changed it.  18469 is Default
+export OBALLOWEDIP=''	# Allow connections from this IP. Set to 0.0.0.0 to allow all or blank to ignore.


### PR DESCRIPTION
This PR adds OBALLOWEDIP setting to control `-a` parameter on restart

Set it to blank `''` (default) to keep original functionality.